### PR TITLE
add LibreOffice Korean team works

### DIFF
--- a/201906.md
+++ b/201906.md
@@ -45,3 +45,8 @@
 ## Summernote
   - https://github.com/summernote/summernote/pull/3285
   - https://github.com/summernote/summernote/pull/3284
+
+## LibreOffice
+ - [tdf#126157 - Request for new Koreanic languages](https://bugs.documentfoundation.org/show_bug.cgi?id=126157)
+ - [LibreOffice Wiki Korean main page](https://wiki.documentfoundation.org/Main_Page/ko)
+ - Korean Translation - https://translations.documentfoundation.org/ko/


### PR DESCRIPTION
LibreOffice Korean team(리브레오피스 우리말 모듬)에서 작업한 이력 공유
[LibreOffice Korea team의 2019년 6월 29일 기록](https://github.com/libreoffice-kr/eventlog/blob/master/2019/20190629.md)